### PR TITLE
Feat: Add Exception with ControllerAdvice

### DIFF
--- a/src/main/java/dogpath/server/dogpath/domain/walk/service/WalkService.java
+++ b/src/main/java/dogpath/server/dogpath/domain/walk/service/WalkService.java
@@ -10,6 +10,7 @@ import dogpath.server.dogpath.domain.walk.dto.GetPathRecordResponse;
 import dogpath.server.dogpath.domain.walk.dto.GetPathRecordsResponse;
 import dogpath.server.dogpath.domain.walk.dto.PathRecordDTO;
 import dogpath.server.dogpath.domain.walk.repository.WalkRepository;
+import dogpath.server.dogpath.global.exception.notfound.WalkEvaluationsNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -62,12 +63,15 @@ public class WalkService {
     }
 
 
-    // TODO: 테스트 기능 추가, 예외 처리
     @Transactional
     public HttpStatus deletePathRecordById(Long walkId) {
 
         // WalkEvaluation 가져오기
         List<WalkEvaluation> walkEvaluations = walkEvaluationRepository.findByWalkId(walkId);
+
+        if (walkEvaluations.isEmpty()) {
+            throw new WalkEvaluationsNotFoundException();
+        }
 
         for (WalkEvaluation walkEvaluation : walkEvaluations) {
             Long evalId = walkEvaluation.getEvaluation().getId();

--- a/src/main/java/dogpath/server/dogpath/global/dto/BaseErrorResponse.java
+++ b/src/main/java/dogpath/server/dogpath/global/dto/BaseErrorResponse.java
@@ -1,0 +1,31 @@
+package dogpath.server.dogpath.global.dto;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@JsonPropertyOrder({"code", "status", "message", "timestamp"})
+public class BaseErrorResponse {
+
+    private final int code;
+    private final int status;
+    private final String message;
+    private final LocalDateTime timestamp;
+
+    public BaseErrorResponse(BaseExceptionResponseStatus status) {
+        this.code = status.getCode();
+        this.status = status.getStatus();
+        this.message = status.getMessage();
+        this.timestamp = LocalDateTime.now();
+    }
+
+    public BaseErrorResponse(BaseExceptionResponseStatus status, String message) {
+        this.code = status.getCode();
+        this.status = status.getStatus();
+        this.message = message;
+        this.timestamp = LocalDateTime.now();
+    }
+
+}

--- a/src/main/java/dogpath/server/dogpath/global/dto/BaseExceptionResponseStatus.java
+++ b/src/main/java/dogpath/server/dogpath/global/dto/BaseExceptionResponseStatus.java
@@ -7,7 +7,7 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor
-public enum ResponseStatus {
+public enum BaseExceptionResponseStatus {
 
     /**
      * 1000: 요청 성공 (OK)
@@ -28,6 +28,7 @@ public enum ResponseStatus {
     SERVER_ERROR(3000, HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버에서 오류가 발생하였습니다."),
     DATABASE_ERROR(3001, HttpStatus.INTERNAL_SERVER_ERROR.value(), "데이터베이스에서 오류가 발생하였습니다."),
     BAD_SQL_GRAMMAR(3002, HttpStatus.INTERNAL_SERVER_ERROR.value(), "SQL에 오류가 있습니다."),
+    WALK_EVALUATION_NOT_FOUND(3003, HttpStatus.INTERNAL_SERVER_ERROR.value(), "산책 기록의 평가 항목을 찾을 수 없습니다."),
     NOT_DEFINED_ERROR(3999, HttpStatus.INTERNAL_SERVER_ERROR.value(),"정의되지 않은 오류입니다.");
 
     private final int code;

--- a/src/main/java/dogpath/server/dogpath/global/dto/BaseResponse.java
+++ b/src/main/java/dogpath/server/dogpath/global/dto/BaseResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-import static dogpath.server.dogpath.global.dto.ResponseStatus.SUCCESS;
+import static dogpath.server.dogpath.global.dto.BaseExceptionResponseStatus.SUCCESS;
 
 @Getter
 @JsonPropertyOrder({"code", "status", "message", "timestamp", "result"})
@@ -27,7 +27,7 @@ public class BaseResponse<T> {
         this.timestamp = LocalDateTime.now();
         this.result = result;
     }
-    public BaseResponse(ResponseStatus status) {
+    public BaseResponse(BaseExceptionResponseStatus status) {
         this.code = status.getCode();
         this.status = status.getStatus();
         this.message = status.getMessage();
@@ -35,7 +35,7 @@ public class BaseResponse<T> {
         this.timestamp = LocalDateTime.now();
     }
 
-    public BaseResponse(ResponseStatus status, String message) {
+    public BaseResponse(BaseExceptionResponseStatus status, String message) {
         this.code = status.getCode();
         this.status = status.getStatus();
         this.message = message;

--- a/src/main/java/dogpath/server/dogpath/global/exception/DatabaseException.java
+++ b/src/main/java/dogpath/server/dogpath/global/exception/DatabaseException.java
@@ -1,0 +1,14 @@
+package dogpath.server.dogpath.global.exception;
+
+import dogpath.server.dogpath.global.dto.BaseExceptionResponseStatus;
+import lombok.Getter;
+
+@Getter
+public class DatabaseException extends RuntimeException {
+    private final BaseExceptionResponseStatus baseExceptionResponseStatus;
+
+    public DatabaseException(BaseExceptionResponseStatus baseExceptionResponseStatus) {
+        super(baseExceptionResponseStatus.getMessage());
+        this.baseExceptionResponseStatus = baseExceptionResponseStatus;
+    }
+}

--- a/src/main/java/dogpath/server/dogpath/global/exception/handler/ExceptionControllerAdvice.java
+++ b/src/main/java/dogpath/server/dogpath/global/exception/handler/ExceptionControllerAdvice.java
@@ -1,12 +1,18 @@
 package dogpath.server.dogpath.global.exception.handler;
 
+import dogpath.server.dogpath.global.dto.BaseErrorResponse;
 import dogpath.server.dogpath.global.dto.BaseResponse;
-import dogpath.server.dogpath.global.dto.ResponseStatus;
+import dogpath.server.dogpath.global.dto.BaseExceptionResponseStatus;
 import dogpath.server.dogpath.global.exception.DogPathException;
+import dogpath.server.dogpath.global.exception.notfound.WalkEvaluationsNotFoundException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static dogpath.server.dogpath.global.dto.BaseExceptionResponseStatus.*;
 
 @Slf4j
 @RestControllerAdvice
@@ -15,7 +21,16 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler(DogPathException.class)
     public ResponseEntity<BaseResponse> baseErrorResponse(Exception e){
         log.error(e.getMessage());
-        return ResponseEntity.status(ResponseStatus.NOT_DEFINED_ERROR.getStatus())
-                .body(new BaseResponse(ResponseStatus.NOT_DEFINED_ERROR, "정의되지 않은 서버 에러입니다."));
+        return ResponseEntity.status(NOT_DEFINED_ERROR.getStatus())
+                .body(new BaseResponse(NOT_DEFINED_ERROR, "정의되지 않은 서버 에러입니다."));
     }
+
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(WalkEvaluationsNotFoundException.class)
+    public BaseErrorResponse handleWalkEvaluationsNotFoundException(WalkEvaluationsNotFoundException e) {
+        log.error("[exceptionHandle] WalkEvaluationsNotFoundException]", e);
+        return new BaseErrorResponse(WALK_EVALUATION_NOT_FOUND);
+    }
+
 }

--- a/src/main/java/dogpath/server/dogpath/global/exception/notfound/WalkEvaluationsNotFoundException.java
+++ b/src/main/java/dogpath/server/dogpath/global/exception/notfound/WalkEvaluationsNotFoundException.java
@@ -1,0 +1,11 @@
+package dogpath.server.dogpath.global.exception.notfound;
+
+import dogpath.server.dogpath.global.dto.BaseExceptionResponseStatus;
+import dogpath.server.dogpath.global.exception.DatabaseException;
+
+public class WalkEvaluationsNotFoundException extends DatabaseException {
+
+    public WalkEvaluationsNotFoundException() {
+        super(BaseExceptionResponseStatus.WALK_EVALUATION_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #17 

## 📝작업 내용

1. `BaseErrorResponse` 추가: 에러 발생 시 프론트에 추가 메시지 출력  
2. `ResponseStatus` Enum 이름 변경: `BaseExceptionResponseStatus`  
- ControllerAdvice에 적용 시 Spring Framework 내부의 ResponseStatus와 어노테이션 이름이 겹쳐서 import 불가능한 현상 발생. 
3.  WalkEvaluation 예외 처리  
-   walkId로 WalkEvaluation 조회 불가능한 경우 `WalkEvaluationsNotFoundException` 호출

추후 다른 예외들도 처리 예정입니다.