### PR TITLE
Feat : 단계별 거리 조절 및 방문노드 예외처리

### DIFF
--- a/src/main/java/dogpath/server/dogpath/domain/path/algorithm/Range.java
+++ b/src/main/java/dogpath/server/dogpath/domain/path/algorithm/Range.java
@@ -13,8 +13,8 @@ public class Range {
 
     public static Range fromWalkLength(WalkLength walkLength, AllowanceDistance allowanceDistance) {
         int standardLength = walkLength.getMeter();
-        double minRange = standardLength * (1 - allowanceDistance.getRange());
-        double maxRange = standardLength * (1 + allowanceDistance.getRange());
+        double minRange = standardLength * (1 - allowanceDistance.getRange()/2);
+        double maxRange = standardLength * (1 + allowanceDistance.getRange()*2);
         return new Range(minRange, maxRange);
     }
 

--- a/src/main/java/dogpath/server/dogpath/domain/path/algorithm/SearchAlgorithm.java
+++ b/src/main/java/dogpath/server/dogpath/domain/path/algorithm/SearchAlgorithm.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.lang.Thread.sleep;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -34,9 +36,11 @@ public class SearchAlgorithm {
 
         //step 1
         List<Node> nodes = calculatedBoard.getAllNodes();
+        calculatedBoard.printBoard();
         nodes.sort((node1, node2) -> {
             if (node1.getScore() > node2.getScore()) return -1;
-            else return 1;
+            if (node1.getScore() < node2.getScore()) return 1;
+            return 0;
         });
 //        log.info("전체 노드 정보");
 //        log.info(nodes.toString());
@@ -160,8 +164,8 @@ public class SearchAlgorithm {
         List<Node> routeCoordinates = new ArrayList<>();
         passingNode.add(0, startNode); // 출발지 노드로 사용
 //        passingNode.add(startNode); // 목적지 노드로 사용
-//        log.info("시작지 + 경유지 + 목적지(시작지) 노드 개수");
-//        log.info(String.valueOf(passingNode.size()));
+        log.info("시작지 + 경유지 + 목적지(시작지) 노드 개수");
+        log.info(String.valueOf(passingNode.size()));
         for (int i = 0; i < passingNode.size() - 1; i++) {
             List<Node> sectionRoute = getSectionRoute(board, passingNode.get(i), passingNode.get(i + 1));
             routeCoordinates.addAll(sectionRoute);
@@ -185,6 +189,7 @@ public class SearchAlgorithm {
             List<Node> neighborNode = board.getNeighborNodes(currentNode); // 근처 8개 노드 가져옴)
             currentNode = findNextNode(neighborNode, endNode); // 근처 노드들 중 다음 노드 선택(휴리스틱 알고리즘 통한 노드별 값 측정 및 비교)
             sectionNodes.add(currentNode);
+            log.info(sectionNodes.toString());
 //            log.info("SectionNodes");
 //            log.info(sectionNodes.toString());
         }
@@ -197,9 +202,9 @@ public class SearchAlgorithm {
 
         for (int i = 0; i < neighborNode.size(); i++) {
             Node node = neighborNode.get(i);
-//            if (node.isVisited()) {
-//                continue;
-//            }
+            if (node.isVisited()) {
+                continue;
+            }
             //목적지라면 바로 가기
             if (node.equals(destination)) {
                 node.isVisited = true;
@@ -213,9 +218,18 @@ public class SearchAlgorithm {
                 nextNode = node;
             }
         }
-        //TODO : 모든 이웃 노드들이 isvisited 상태이면 문제 생김.
         if (nextNode == null) {
-            nextNode = neighborNode.get(0);
+            Node minNode = null;
+            double minDisatnce = Double.MAX_VALUE;
+            for (int i = 0; i < neighborNode.size(); i++) {
+                Node node = neighborNode.get(i);
+                double distance = node.calculateHaversineDistance(destination);
+                if (distance < minDisatnce) {
+                    minDisatnce = distance;
+                    minNode = node;
+                }
+            }
+            nextNode = minNode;
         }
         nextNode.isVisited = true;
         return nextNode;

--- a/src/main/java/dogpath/server/dogpath/domain/path/algorithm/enums/AllowanceDistance.java
+++ b/src/main/java/dogpath/server/dogpath/domain/path/algorithm/enums/AllowanceDistance.java
@@ -11,8 +11,8 @@ public enum AllowanceDistance {
         짧은 산책 -> 10% / 중간 산책 -> 10% / 긴 산책 -> 10% (조절가능)
      */
     SHORT(0.1),
-    MEDIUM(0.1),
-    LONG(0.1);
+    MEDIUM(0.15),
+    LONG(0.2);
 
     private double range;
 

--- a/src/main/java/dogpath/server/dogpath/domain/path/algorithm/enums/WalkLength.java
+++ b/src/main/java/dogpath/server/dogpath/domain/path/algorithm/enums/WalkLength.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 public enum WalkLength {
     // Value의 의미: 한 변에 포함되는 Node의 개수
     SHORT(5),
-    MEDIUM(10),
-    LONG(20);
+    MEDIUM(7),
+    LONG(8);
 
     private final int value;
 
@@ -16,6 +16,15 @@ public enum WalkLength {
     }
 
     public int getMeter(){
+        if (this == SHORT) {
+            return 1000;
+        }
+        if (this == MEDIUM) {
+            return 2000;
+        }
+        if (this == LONG) {
+            return 4000;
+        }
         return (this.value/5 * 1000);
     }
 }

--- a/src/main/java/dogpath/server/dogpath/domain/path/service/PathService.java
+++ b/src/main/java/dogpath/server/dogpath/domain/path/service/PathService.java
@@ -84,11 +84,6 @@ public class PathService {
         log.info(allowanceDistance.toString());
         log.info(range.toString());
         log.info(String.valueOf(distance));
-//        try {
-//            sleep(3000); // TODO :삭제 필요
-//        } catch (InterruptedException e) {
-//            throw new RuntimeException(e);
-//        }
         return range.inRange(distance);
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #5 

## 📝작업 내용

### 단계별 최적 거리 출력을 위한 값 조정
```
SHORT : 1000m
MEDIUN : 2000m
Long : 4000m
```
- 걷는 거리 기준으로 알고리즘 최적화를 위해 기존 `WalkLength`의 값 5, 10, 20을 5, 7, 8로 수정
- 허용 거리의 최소치 -10%, -10%, -10% -> -5%, -7.5%, -10%로 수정
- 허용 거리의 최대치 +10%, +10%, +10% -> +10%, +15%, +20%로 수정

### 방문 노드 예외처리
이전)
현재 위치 기준 8방면을 탐색하는 로직으로 구성되어 있음. 위치에 따라 최소 3방면 ~ 8방면 탐색
이때, 3~8개의 노드들이 이전에 방문한 노드면 탐색이 불가능해지며, 다음 갈 노드를 탐색 못해 길을 잃게 됨.

수정 후) 
이미 방문한 노드여도, 근처에서 최대 가중치를 갖는 노드로 탐색하도록 유도

추가 수정안) 
노드의 개수 증가하면 대부분의 경우 해결가능하나 최선의 방법은 아님.

## TODO
- [ ] 방문 노드에 대해 해결책 필요
- [ ] 출력된 경로에 대해서 실효성 검사 필요